### PR TITLE
leverage reusable workflows and add actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - public

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,11 +12,11 @@ jobs:
   lint:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/pre-commit.yaml@main
     with:
-      python-version: ${{ env.MIN_PYTHON_VERSION }}
+      python-version: "3.10"  # can't leverage env vars here
   mypy:
     uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main
     with:
-      python-version: ${{ env.MIN_PYTHON_VERSION }}
+      python-version: "3.10"  # can't leverage env vars here
 
   unit-tests:
     timeout-minutes: 5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,31 +10,13 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b  # v3
-      - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
-        with:
-          python-version: ${{ env.MIN_PYTHON_VERSION }}
-      - name: pre-commit
-        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507  # v3
+    uses: bridgecrewio/gha-reusable-workflows/.github/workflows/pre-commit.yaml@main
+    with:
+      python-version: ${{ env.MIN_PYTHON_VERSION }}
   mypy:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b  # v3
-    - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912  # v4
-      with:
-        python-version: ${{ env.MIN_PYTHON_VERSION }}
-    - name: Install pipenv
-      run: |
-        python -m pip install --no-cache-dir --upgrade pipenv
-    - name: Install dependencies
-      run: |
-        pipenv --python ${{ env.MIN_PYTHON_VERSION }}
-        pipenv install --dev
-    - name: Run Mypy
-      run: |
-        pipenv run mypy
+    uses: bridgecrewio/gha-reusable-workflows/.github/workflows/mypy.yaml@main
+    with:
+      python-version: ${{ env.MIN_PYTHON_VERSION }}
 
   unit-tests:
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,11 @@ jobs:
         id: version
         run: |
           version=$(curl -s curl -s https://api.github.com/repos/bridgecrewio/checkov/tags | jq -r '.[0].name')
-          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
           # grab major version for later image tag usage
           major_version=$(echo "${version}" | head -c1)
-          echo "major_version=$major_version" >> $GITHUB_OUTPUT
+          echo "major_version=$major_version" >> "$GITHUB_OUTPUT"
       - name: Update checkov dependency
         run: |
           # install needed tools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
       - id: ruff
         args:
           - --fix
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.22
+    hooks:
+      - id: actionlint-docker
+        args: ["-ignore", "context \"env\" is not allowed here."]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,3 @@ repos:
     rev: v1.6.22
     hooks:
       - id: actionlint-docker
-        args: ["-ignore", "context \"env\" is not allowed here."]


### PR DESCRIPTION
- replaced `mypy` and `pre-commit` job with our reusable workflows
- added `actionlint` for linting GHA workflow files