### PR TITLE
Fix stale Checkov runner state between scans

### DIFF
--- a/app/checkov_whorf.py
+++ b/app/checkov_whorf.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from checkov.common.output.baseline import Baseline
     from checkov.common.output.report import Report
     from checkov.common.runners.runner_registry import RunnerRegistry
+    from checkov.common.sast.consts import SastLanguages
 
 
 class CheckovWhorf(Checkov):
@@ -22,6 +23,11 @@ class CheckovWhorf(Checkov):
         super().__init__(argv=argv)
 
         self.logger = logger
+
+        # Checkov shallow-copies a module-level list of runner instances into each
+        # Checkov object. Some runners retain scan state, so replace them with fresh
+        # instances to prevent stale manifests from leaking between requests.
+        self.runners = [runner.__class__() for runner in self.runners]
 
     def upload_results(
         self,
@@ -32,6 +38,7 @@ class CheckovWhorf(Checkov):
         included_paths: list[str] | None = None,
         git_configuration_folders: list[str] | None = None,
         sca_supported_ir_report: Report | None = None,
+        sast_languages: set[SastLanguages] | None = None,
     ) -> None:
         # don't upload results with every run
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,3 +209,13 @@ def package_record() -> Record:
             "fixed_versions": [],
         },
     )
+
+
+@pytest.fixture()
+def minimal_deployment_manifest() -> str:
+    return (Path(__file__).parent / "manifests/deployment-minimal.yaml").read_text()
+
+
+@pytest.fixture()
+def hostpid_deployment_manifest() -> str:
+    return (Path(__file__).parent / "manifests/deployment-hostpid.yaml").read_text()

--- a/tests/manifests/deployment-hostpid.yaml
+++ b/tests/manifests/deployment-hostpid.yaml
@@ -1,0 +1,19 @@
+# Deployment that fails CKV_K8S_17 "Containers should not share the host process ID namespace"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hostpid-enabled
+  namespace: test
+spec:
+  selector:
+    matchLabels:
+      app: hostpid-enabled
+  template:
+    metadata:
+      labels:
+        app: hostpid-enabled
+    spec:
+      hostPID: true
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/tests/manifests/deployment-minimal.yaml
+++ b/tests/manifests/deployment-minimal.yaml
@@ -1,0 +1,18 @@
+# Minimal valid deployment used by check-specific tests
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minimal
+  namespace: test
+spec:
+  selector:
+    matchLabels:
+      app: minimal
+  template:
+    metadata:
+      labels:
+        app: minimal
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.25

--- a/tests/test_checkov_whorf.py
+++ b/tests/test_checkov_whorf.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from checkov.common.output.report import Report
+from pytest_mock import MockerFixture
+
+import app.checkov_whorf
+from app.checkov_whorf import CheckovWhorf
+from app.consts import DEFAULT_CHECKOV_ARGS
+
+
+@pytest.mark.parametrize(
+    (
+        "first_manifest_fixture",
+        "first_manifest_scan_results",
+        "second_manifest_fixture",
+        "second_manifest_scan_results",
+    ),
+    [
+        pytest.param(
+            "minimal_deployment_manifest",
+            [("passed_checks", "Deployment.test.minimal")],
+            "hostpid_deployment_manifest",
+            [("failed_checks", "Deployment.test.hostpid-enabled")],
+            id="pass-then-fail",
+        ),
+        pytest.param(
+            "hostpid_deployment_manifest",
+            [("failed_checks", "Deployment.test.hostpid-enabled")],
+            "minimal_deployment_manifest",
+            [("passed_checks", "Deployment.test.minimal")],
+            id="fail-then-pass",
+        ),
+    ],
+)
+def test_checkov_whorf_instances_do_not_share_runner_state(
+    mocker: MockerFixture,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    first_manifest_fixture: str,
+    first_manifest_scan_results: list[tuple[str, str]],
+    second_manifest_fixture: str,
+    second_manifest_scan_results: list[tuple[str, str]],
+) -> None:
+    checkov_conf_path = tmp_path / ".checkov.yaml"
+    checkov_conf_path.write_text(
+        "\n".join(
+            [
+                "framework: kubernetes",
+                "check:",
+                "- CKV_K8S_17",
+                "skip-download: true",
+            ]
+        )
+    )
+    mocker.patch.object(app.checkov_whorf, "CHECKOV_CONFIG_PATH", checkov_conf_path)
+
+    first_manifest_path = tmp_path / "first.yaml"
+    first_manifest_path.write_text(str(request.getfixturevalue(first_manifest_fixture)))
+    second_manifest_path = tmp_path / "second.yaml"
+    second_manifest_path.write_text(str(request.getfixturevalue(second_manifest_fixture)))
+
+    first_scan_reports = _scan_file(first_manifest_path)
+    assert _scan_report_results(first_scan_reports, ["CKV_K8S_17"]) == first_manifest_scan_results
+
+    second_scan_reports = _scan_file(second_manifest_path)
+    assert _scan_report_results(second_scan_reports, ["CKV_K8S_17"]) == second_manifest_scan_results
+
+
+def _scan_file(file_path: Path) -> list[Report]:
+    ckv_whorf = CheckovWhorf(logger=MagicMock(), argv=DEFAULT_CHECKOV_ARGS)
+    ckv_whorf.update_config()
+    ckv_whorf.scan_file(file=str(file_path))
+    return ckv_whorf.scan_reports
+
+
+def _scan_report_results(
+    reports: list[Report],
+    check_ids: list[str],
+) -> list[tuple[str, str]]:
+    return [
+        (result_type, record.resource)
+        for report in reports
+        for result_type, records in (
+            ("passed_checks", report.passed_checks),
+            ("failed_checks", report.failed_checks),
+        )
+        for record in records
+        if record.check_id in check_ids
+    ]


### PR DESCRIPTION
## Summary

- create fresh Checkov runner instances for each `CheckovWhorf` instance
- add regression coverage for consecutive Kubernetes scans in the same process
- align the `upload_results` override with Checkov's current signature

## Problem

`Checkov.__init__` shallow-copies a module-level list of instantiated runners. Some runners retain mutable scan state, so a later admission request can process manifest data left behind by an earlier request.

## Solution

Replace the shallow-copied runners with newly constructed instances whenever Whorf creates a Checkov scanner.
